### PR TITLE
improve precision for linear11 encoded data

### DIFF
--- a/corsair-psu.c
+++ b/corsair-psu.c
@@ -2,7 +2,6 @@
 /*
  * corsair-psu.c - Linux driver for Corsair power supplies with HID sensors interface
  * Copyright (C) 2020 Wilken Gottwalt <wilken.gottwalt@posteo.net>
- * Copyright (C) 2020 Jack Doan <me@jackdoan.com>
  */
 
 #include <linux/completion.h>
@@ -596,5 +595,4 @@ module_hid_driver(corsairpsu_driver);
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Wilken Gottwalt <wilken.gottwalt@posteo.net>");
-MODULE_AUTHOR("Jack Doan <me@jackdoan.com>");
 MODULE_DESCRIPTION("Linux driver for Corsair power supplies with HID sensors interface");

--- a/corsair-psu.c
+++ b/corsair-psu.c
@@ -2,6 +2,7 @@
 /*
  * corsair-psu.c - Linux driver for Corsair power supplies with HID sensors interface
  * Copyright (C) 2020 Wilken Gottwalt <wilken.gottwalt@posteo.net>
+ * Copyright (C) 2020 Jack Doan <me@jackdoan.com>
  */
 
 #include <linux/completion.h>
@@ -595,4 +596,5 @@ module_hid_driver(corsairpsu_driver);
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Wilken Gottwalt <wilken.gottwalt@posteo.net>");
+MODULE_AUTHOR("Jack Doan <me@jackdoan.com>");
 MODULE_DESCRIPTION("Linux driver for Corsair power supplies with HID sensors interface");


### PR DESCRIPTION
Howdy!

I was giving this driver a spin when I noticed the values reported the linear11 encoded values looked a little too 'nice'. I took a closer look, and it turns out that precision was being lost because the values were (correctly) interpreted from linear11 & then scaled to fit what hwmon expects. By reversing that order, we can get better data:
Before:
```
corsairpsu-hid-3-cd
Adapter: HID adapter
v_in:        115.00 V  
v_out +12v:   12.00 V  
v_out +5v:     5.00 V  
v_out +3.3v:   3.00 V  
psu fan:        0 RPM
vrm temp:     +47.0°C  
case temp:    +37.0°C  
power total: 216.00 W  
power +12v:  184.00 W  
power +5v:    20.00 W  
power +3.3v:  12.00 W  
curr in:          N/A  
curr +12v:    15.00 A  
curr +5v:      4.00 A  
curr +3.3v:    3.00 A  
```
After
```
corsairpsu-hid-3-cd
Adapter: HID adapter
v_in:        115.00 V  
v_out +12v:   12.14 V  
v_out +5v:     5.01 V  
v_out +3.3v:   3.30 V  
psu fan:        0 RPM
vrm temp:     +47.0°C  
case temp:    +36.8°C  
power total: 210.00 W  
power +12v:  178.00 W  
power +5v:    20.00 W  
power +3.3v:  11.50 W  
curr in:          N/A  
curr +12v:    14.75 A  
curr +5v:      4.00 A  
curr +3.3v:    3.44 A 
```

I also renamed "length" to "address" where appropriate with regard to the pseudo-pmbus communication.