### PR TITLE
Add limits and fans

### DIFF
--- a/corsair-psu.c
+++ b/corsair-psu.c
@@ -302,7 +302,7 @@ static umode_t corsairpsu_hwmon_ops_is_visible(const void *data, enum hwmon_sens
 		return 0444;
 	else if (type == hwmon_fan && (attr == hwmon_fan_input || attr == hwmon_fan_label))
 		return 0444;
-	else if (type == hwmon_pwm && (attr == hwmon_pwm_input || attr == hwmon_pwm_mode))
+	else if (type == hwmon_pwm && (attr == hwmon_pwm_input || attr == hwmon_pwm_enable))
 		return 0644;
 	else if (type == hwmon_power && (attr == hwmon_power_input || attr == hwmon_power_label))
 		return 0444;
@@ -337,7 +337,7 @@ static int corsairpsu_hwmon_ops_read(struct device *dev, enum hwmon_sensor_types
 		case hwmon_pwm_input:
 			ret = corsairpsu_get_value(priv, PSU_CMD_FAN_DUTY_CYCLE, 0, val);
 			break;
-		case hwmon_pwm_mode:
+		case hwmon_pwm_enable:
 			ret = corsairpsu_get_value(priv, PSU_CMD_FAN_MODE, 0, val);
 			break;
 		default:
@@ -457,7 +457,7 @@ static int corsairpsu_hwmon_ops_write(struct device *dev, enum hwmon_sensor_type
 					return 1;
 			}
 			break;
-		case hwmon_pwm_mode:
+		case hwmon_pwm_enable:
 			if(channel == 0) { // fan ctrl mode, 0 = hw, 1 = sw
 				switch(val) {
 				case 0:
@@ -495,7 +495,7 @@ static const struct hwmon_channel_info *corsairpsu_info[] = {
 	HWMON_CHANNEL_INFO(fan,
 			   HWMON_F_INPUT | HWMON_F_LABEL),
 	HWMON_CHANNEL_INFO(pwm,
-					HWMON_PWM_INPUT | HWMON_PWM_MODE),
+					HWMON_PWM_INPUT | HWMON_PWM_ENABLE),
 	HWMON_CHANNEL_INFO(power,
 			   HWMON_P_INPUT | HWMON_P_LABEL,
 			   HWMON_P_INPUT | HWMON_P_LABEL,

--- a/corsair-psu.c
+++ b/corsair-psu.c
@@ -298,7 +298,7 @@ static umode_t corsairpsu_hwmon_ops_is_visible(const void *data, enum hwmon_sens
 					       u32 attr, int channel)
 {
 	if (type == hwmon_temp && (attr == hwmon_temp_input || attr == hwmon_temp_label
-	|| attr == hwmon_temp_rated_max))
+	|| attr == hwmon_temp_crit))
 		return 0444;
 	else if (type == hwmon_fan && (attr == hwmon_fan_input || attr == hwmon_fan_label))
 		return 0444;
@@ -307,10 +307,10 @@ static umode_t corsairpsu_hwmon_ops_is_visible(const void *data, enum hwmon_sens
 	else if (type == hwmon_power && (attr == hwmon_power_input || attr == hwmon_power_label))
 		return 0444;
 	else if (type == hwmon_in && (attr == hwmon_in_input || attr == hwmon_in_label
-	|| attr == hwmon_in_rated_max || attr == hwmon_in_rated_min))
+	|| attr == hwmon_in_crit || attr == hwmon_in_lcrit))
 		return 0444;
 	else if (type == hwmon_curr && (attr == hwmon_curr_input || attr == hwmon_curr_label
-	|| attr == hwmon_curr_rated_max || attr == hwmon_curr_rated_min) && channel != 0)
+	|| attr == hwmon_curr_crit) && channel != 0)
 		return 0444;
 
 	return 0;
@@ -327,7 +327,7 @@ static int corsairpsu_hwmon_ops_read(struct device *dev, enum hwmon_sensor_types
 			ret = corsairpsu_get_value(priv,
 									   channel ? PSU_CMD_TEMP1 : PSU_CMD_TEMP0, channel, val);
 		}
-		else if(attr == hwmon_temp_rated_max) {
+		else if(attr == hwmon_temp_crit) {
 			ret = corsairpsu_get_value(priv, PSU_CMD_RAIL_TEMP_FAULT, 0, val);
 		}
 	} else if (type == hwmon_fan && attr == hwmon_fan_input) {
@@ -368,13 +368,13 @@ static int corsairpsu_hwmon_ops_read(struct device *dev, enum hwmon_sensor_types
 				return -EOPNOTSUPP;
 			}
 			break;
-		case hwmon_in_rated_max:
+		case hwmon_in_crit:
 			if(channel >= 1 && channel <= 3)
 				ret = corsairpsu_get_value(priv, PSU_CMD_RAIL_OV_FAULT, channel - 1, val);
 			else
 				return -EOPNOTSUPP;
 			break;
-		case hwmon_in_rated_min:
+		case hwmon_in_lcrit:
 			if(channel >= 1 && channel <= 3)
 				ret = corsairpsu_get_value(priv, PSU_CMD_RAIL_UV_FAULT, channel - 1, val);
 			else
@@ -397,7 +397,7 @@ static int corsairpsu_hwmon_ops_read(struct device *dev, enum hwmon_sensor_types
 				return -EOPNOTSUPP;
 			}
 			break;
-		case hwmon_curr_rated_max:
+		case hwmon_curr_crit:
 			if(channel >= 1 && channel <= 3)
 				ret = corsairpsu_get_value(priv, PSU_CMD_RAIL_OC_FAULT, channel - 1, val);
 			else
@@ -490,8 +490,8 @@ static const struct hwmon_channel_info *corsairpsu_info[] = {
 	HWMON_CHANNEL_INFO(chip,
 			   HWMON_C_REGISTER_TZ),
 	HWMON_CHANNEL_INFO(temp,
-			   HWMON_T_INPUT | HWMON_T_LABEL | HWMON_T_RATED_MAX,
-			   HWMON_T_INPUT | HWMON_T_LABEL | HWMON_T_RATED_MAX),
+			   HWMON_T_INPUT | HWMON_T_LABEL | HWMON_T_CRIT,
+			   HWMON_T_INPUT | HWMON_T_LABEL | HWMON_T_CRIT),
 	HWMON_CHANNEL_INFO(fan,
 			   HWMON_F_INPUT | HWMON_F_LABEL),
 	HWMON_CHANNEL_INFO(pwm,
@@ -503,14 +503,14 @@ static const struct hwmon_channel_info *corsairpsu_info[] = {
 			   HWMON_P_INPUT | HWMON_P_LABEL),
 	HWMON_CHANNEL_INFO(in,
 			   HWMON_I_INPUT | HWMON_I_LABEL,
-			   HWMON_I_INPUT | HWMON_I_LABEL | HWMON_I_RATED_MAX | HWMON_I_RATED_MIN,
-			   HWMON_I_INPUT | HWMON_I_LABEL | HWMON_I_RATED_MAX | HWMON_I_RATED_MIN,
-			   HWMON_I_INPUT | HWMON_I_LABEL | HWMON_I_RATED_MAX | HWMON_I_RATED_MIN),
+			   HWMON_I_INPUT | HWMON_I_LABEL | HWMON_I_CRIT | HWMON_I_LCRIT,
+			   HWMON_I_INPUT | HWMON_I_LABEL | HWMON_I_CRIT | HWMON_I_LCRIT,
+			   HWMON_I_INPUT | HWMON_I_LABEL | HWMON_I_CRIT | HWMON_I_LCRIT),
 	HWMON_CHANNEL_INFO(curr,
 			   HWMON_C_INPUT | HWMON_C_LABEL,
-			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_RATED_MAX,
-			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_RATED_MAX,
-			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_RATED_MAX),
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_CRIT,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_CRIT,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_CRIT),
 	NULL
 };
 


### PR DESCRIPTION
Added limits for voltages/currents/temperature as reported by the PSU:
```
corsairpsu-hid-3-cf
Adapter: HID adapter
v_in:        115.00 V  
v_out +12v:   12.00 V  (crit min =  +8.00 V, crit max = +15.00 V)
v_out +5v:     5.00 V  (crit min =  +3.00 V, crit max =  +6.00 V)
v_out +3.3v:   3.00 V  (crit min =  +2.00 V, crit max =  +4.00 V)
psu fan:        0 RPM
vrm temp:     +46.0°C  (crit = +70.0°C)
case temp:    +36.0°C  (crit = +70.0°C)
power total: 216.00 W  
power +12v:  184.00 W  
power +5v:    20.00 W  
power +3.3v:  11.00 W  
curr +12v:    15.00 A  (crit max = +85.00 A)
curr +5v:      4.00 A  (crit max = +40.00 A)
curr +3.3v:    3.00 A  (crit max = +40.00 A)
```

Added fan control via pwm1
pwm1_mode
- 0: hardware control
- 1: control via 'pwm1'
- fan0 will always report 0 if pwm1_mode is set to 0

pwm1:
- set fan duty cycle, from 0 to 255
- PSU will reject speeds that are too low / it doesn't like with "invalid argument". This is correctly communicated back to userspace.
- floor seems to be at 27% or 68/255
- if read, pwm1 reports the setpoint as a percentage. I can change this to a 0->255 if you'd like for consistency