### PR TITLE
Update todo.txt

### DIFF
--- a/todo.txt
+++ b/todo.txt
@@ -7,7 +7,7 @@ Add more RMi/HXi support
 
 Get support up for the AXi series:
 
-1B1C 1C00 Controller for Corsair Link            AX760i, AX860i, ?AX1200i?
+1B1C 1C00 Controller for Corsair Link            AX760i, AX860i, AX1200i
 1B1C 1C01 ?
 1B1C 1C02 Corsair AX1500i
 1B1C 1C11 Corsair AX1600i


### PR DESCRIPTION
I have checked with an AX1200i and it has the 1B1C:1C00 Controller for Corsair Link identical to the usbdumps/ax860i.txt except for iSerial (unique I guess!) and iInterface ("2" and not "2 Corsair Link TM USB Dongle").