### PR TITLE
Add AX1600i USB hwmon support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ccflags-y = -DEXPORT_SYMTAB
-obj-m := corsair-psu.o
+obj-m := corsair-psu.o corsair-psu-axi.o
 
 KDIR = /lib/modules/$(shell uname -r)/build/
 PWD = $(shell pwd)
@@ -10,6 +10,6 @@ clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
 	
 
-.PHONY: modules clean
+.PHONY: all clean
 
 -include $(KDIR)/Rules.make

--- a/README.md
+++ b/README.md
@@ -2,15 +2,25 @@ This is the main development repository for the corsair-psu hwmon driver which
 is also part of mainline.
 
 The `corsair-psu` driver supports Corsair RMi and HXi series power supplies.
-The separate `corsair-psu-axi` USB driver supports the Corsair AX1600i. The AXi
-driver is read-only and exposes input and rail voltage, current and power,
-temperature, fan speed and mode, and labels through hwmon. It also exposes the
-AX1600i's twelve 12 V pages with per-page current, power, and OCP limits.
-Session uptime and USB bridge metadata are available through debugfs.
+The separate `corsair-psu-axi` USB driver supports the Corsair AX1600i. It
+exposes input and rail voltage, current and power, temperature, fan speed and
+mode, and labels through hwmon. The telemetry interfaces are read-only; fan
+control is available through writable `pwm1` and `pwm1_enable` attributes.
+It also exposes the AX1600i's twelve 12 V pages with per-page current, power,
+and OCP limits. Session uptime and USB bridge metadata are available through
+debugfs.
+
+`pwm1_enable` follows the standard hwmon values: write `2` for the PSU's
+automatic fan controller or `1` for manual control. In manual mode, `pwm1`
+accepts values from 0 to 255 and converts them to the AX1600i's 0-100 percent
+duty-cycle register. Switching to manual mode first sets the fan to 100 percent
+so a stale low duty cycle cannot stop the fan unexpectedly; write the desired
+`pwm1` value after enabling manual mode. A manual `pwm1` value of `0` stops the
+fan, so automatic mode is recommended unless fixed-speed operation is needed.
 
 The AX1600i transport and register protocol is based on the work in
 [corsair-top](https://github.com/thad0ctor/corsair-top). The 12 V page
-telemetry, fan mode, uptime, and USB bridge metadata are based on protocol
+telemetry, fan control, uptime, and USB bridge metadata are based on protocol
 research by [Jon0](https://github.com/Jon0) in
 [Jon0/ax1600i](https://github.com/Jon0/ax1600i).
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@ is also part of mainline.
 The `corsair-psu` driver supports Corsair RMi and HXi series power supplies.
 The separate `corsair-psu-axi` USB driver supports the Corsair AX1600i. The AXi
 driver is read-only and exposes input and rail voltage, current and power,
-temperature, fan speed, and labels through hwmon.
+temperature, fan speed and mode, and labels through hwmon. It also exposes the
+AX1600i's twelve 12 V pages with per-page current, power, and OCP limits.
+Session uptime and USB bridge metadata are available through debugfs.
 
 The AX1600i transport and register protocol is based on the work in
-[corsair-top](https://github.com/thad0ctor/corsair-top).
+[corsair-top](https://github.com/thad0ctor/corsair-top). The 12 V page
+telemetry, fan mode, uptime, and USB bridge metadata are based on protocol
+research by [Jon0](https://github.com/Jon0) in
+[Jon0/ax1600i](https://github.com/Jon0/ax1600i).
 
 Build both modules with `make`. The AX1600i module can then be loaded with
 `modprobe corsair-psu-axi` after installation, or `insmod corsair-psu-axi.ko`

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 This is the main development repository for the corsair-psu hwmon driver which
 is also part of mainline.
 
-This driver supports all Corsair RMi and HXi series power supplies. This repo
-is used to add support for the AXi series power supplies, which are quite
-similar, but do not work with the USB HID code of the mainlined driver.
+The `corsair-psu` driver supports Corsair RMi and HXi series power supplies.
+The separate `corsair-psu-axi` USB driver supports the Corsair AX1600i. The AXi
+driver is read-only and exposes input and rail voltage, current and power,
+temperature, fan speed, and labels through hwmon.
 
-There are also tools to access/test the power supplies using libusb which will
-be added to the kernel driver if it works and is tested.
+The AX1600i transport and register protocol is based on the work in
+[corsair-top](https://github.com/thad0ctor/corsair-top).
+
+Build both modules with `make`. The AX1600i module can then be loaded with
+`modprobe corsair-psu-axi` after installation, or `insmod corsair-psu-axi.ko`
+for development testing.

--- a/corsair-psu-axi.c
+++ b/corsair-psu-axi.c
@@ -8,7 +8,7 @@
  * AX1600i transport and register protocol based on the corsair-top project:
  * https://github.com/thad0ctor/corsair-top
  *
- * 12V page telemetry, fan mode, uptime, and USB bridge metadata based on
+ * 12V page telemetry, fan control, uptime, and USB bridge metadata based on
  * protocol research by Jon0:
  * https://github.com/Jon0/ax1600i
  */
@@ -40,6 +40,7 @@
 #define AXI_CMD_READ		0x08
 
 #define AXI_REG_SELECT_RAIL	0x00
+#define AXI_REG_FAN_PWM		0x3b
 #define AXI_REG_IN_VOLTS	0x88
 #define AXI_REG_IN_AMPS		0x89
 #define AXI_REG_RAIL_VOLTS	0x8b
@@ -66,6 +67,7 @@
 #define AXI_CURR_COUNT		(AXI_BASE_CURR_COUNT + AXI_12V_PAGE_COUNT)
 #define AXI_BRIDGE_VERSION_SIZE	3
 #define AXI_BRIDGE_FIRMWARE_SIZE	64
+#define AXI_SAFE_MANUAL_DUTY	100
 
 #define L_IN_VOLTS		"v_in"
 #define L_OUT_VOLTS_12V		"v_out +12v"
@@ -121,6 +123,7 @@ struct corsairpsu_axi_data {
 	char product[8];
 	bool bridge_version_valid;
 	bool bridge_firmware_valid;
+	bool fan_pwm_supported;
 	bool disconnected;
 };
 
@@ -356,6 +359,16 @@ static int axi_linear11_to_int(u16 raw, int scale, long *value)
 	return 0;
 }
 
+static int axi_dutycycle_to_pwm(u8 dutycycle)
+{
+	return DIV_ROUND_CLOSEST(dutycycle * 255, 100);
+}
+
+static u8 axi_pwm_to_dutycycle(long pwm)
+{
+	return DIV_ROUND_CLOSEST(pwm * 100, 255);
+}
+
 static int axi_get_value(struct corsairpsu_axi_data *priv, u8 reg, int rail,
 			 int scale, long *value)
 {
@@ -396,6 +409,47 @@ static int axi_get_raw(struct corsairpsu_axi_data *priv, u8 reg, u8 *data,
 	return ret;
 }
 
+static int axi_set_raw(struct corsairpsu_axi_data *priv, u8 reg, u8 value)
+{
+	int ret;
+
+	mutex_lock(&priv->lock);
+	if (priv->disconnected)
+		ret = -ENODEV;
+	else
+		ret = axi_write_register_locked(priv, reg, &value, sizeof(value));
+	mutex_unlock(&priv->lock);
+
+	return ret;
+}
+
+static int axi_set_fan_mode(struct corsairpsu_axi_data *priv, bool automatic)
+{
+	u8 value;
+	int ret;
+
+	mutex_lock(&priv->lock);
+	if (priv->disconnected) {
+		ret = -ENODEV;
+		goto out;
+	}
+
+	if (!automatic) {
+		value = AXI_SAFE_MANUAL_DUTY;
+		ret = axi_write_register_locked(priv, AXI_REG_FAN_PWM, &value,
+						sizeof(value));
+		if (ret)
+			goto out;
+	}
+
+	value = automatic ? 0 : 1;
+	ret = axi_write_register_locked(priv, AXI_REG_FAN_MODE, &value,
+					sizeof(value));
+out:
+	mutex_unlock(&priv->lock);
+	return ret;
+}
+
 static int axi_get_12v_page_value(struct corsairpsu_axi_data *priv, u8 reg,
 				  int page, int scale, long *value)
 {
@@ -423,6 +477,8 @@ out:
 static umode_t axi_hwmon_is_visible(const void *data, enum hwmon_sensor_types type,
 				    u32 attr, int channel)
 {
+	const struct corsairpsu_axi_data *priv = data;
+
 	switch (type) {
 	case hwmon_temp:
 		return (attr == hwmon_temp_input || attr == hwmon_temp_label) ? 0444 : 0;
@@ -431,7 +487,13 @@ static umode_t axi_hwmon_is_visible(const void *data, enum hwmon_sensor_types ty
 	case hwmon_power:
 		return (attr == hwmon_power_input || attr == hwmon_power_label) ? 0444 : 0;
 	case hwmon_pwm:
-		return (attr == hwmon_pwm_enable && !channel) ? 0444 : 0;
+		if (channel)
+			return 0;
+		if (attr == hwmon_pwm_enable)
+			return priv->fan_pwm_supported ? 0644 : 0444;
+		if (attr == hwmon_pwm_input && priv->fan_pwm_supported)
+			return 0644;
+		return 0;
 	case hwmon_in:
 		return (attr == hwmon_in_input || attr == hwmon_in_label) ? 0444 : 0;
 	case hwmon_curr:
@@ -473,19 +535,33 @@ static int axi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 		return axi_get_value(priv, AXI_REG_RAIL_WATTS, channel - 1,
 				     1000000, value);
 	case hwmon_pwm:
-		if (attr != hwmon_pwm_enable || channel)
+		if (channel)
 			return -EOPNOTSUPP;
-		ret = axi_get_raw(priv, AXI_REG_FAN_MODE, &data, sizeof(data));
-		if (ret)
-			return ret;
-		/* The PSU reports 0 for automatic mode and 1 for fixed-speed mode. */
-		if (data == 0)
-			*value = 2;
-		else if (data == 1)
-			*value = 1;
-		else
-			return -EIO;
-		return 0;
+		if (attr == hwmon_pwm_input) {
+			if (!priv->fan_pwm_supported)
+				return -EOPNOTSUPP;
+			ret = axi_get_raw(priv, AXI_REG_FAN_PWM, &data, sizeof(data));
+			if (ret)
+				return ret;
+			if (data > 100)
+				return -ERANGE;
+			*value = axi_dutycycle_to_pwm(data);
+			return 0;
+		}
+		if (attr == hwmon_pwm_enable) {
+			ret = axi_get_raw(priv, AXI_REG_FAN_MODE, &data, sizeof(data));
+			if (ret)
+				return ret;
+			/* The PSU reports 0 for automatic mode and 1 for fixed-speed mode. */
+			if (data == 0)
+				*value = 2;
+			else if (data == 1)
+				*value = 1;
+			else
+				return -EIO;
+			return 0;
+		}
+		return -EOPNOTSUPP;
 	case hwmon_in:
 		if (attr != hwmon_in_input || channel > AXI_RAIL_COUNT)
 			return -EOPNOTSUPP;
@@ -511,6 +587,31 @@ static int axi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 		if (!channel)
 			return axi_get_value(priv, AXI_REG_IN_AMPS, -1, 1000, value);
 		return axi_get_value(priv, AXI_REG_RAIL_AMPS, channel - 1, 1000, value);
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static int axi_hwmon_write(struct device *dev, enum hwmon_sensor_types type,
+			   u32 attr, int channel, long value)
+{
+	struct corsairpsu_axi_data *priv = dev_get_drvdata(dev);
+
+	if (type != hwmon_pwm || channel)
+		return -EOPNOTSUPP;
+	if (!priv->fan_pwm_supported)
+		return -EOPNOTSUPP;
+
+	switch (attr) {
+	case hwmon_pwm_input:
+		if (value < 0 || value > 255)
+			return -EINVAL;
+		return axi_set_raw(priv, AXI_REG_FAN_PWM,
+				   axi_pwm_to_dutycycle(value));
+	case hwmon_pwm_enable:
+		if (value != 1 && value != 2)
+			return -EINVAL;
+		return axi_set_fan_mode(priv, value == 2);
 	default:
 		return -EOPNOTSUPP;
 	}
@@ -555,6 +656,7 @@ static int axi_hwmon_read_string(struct device *dev, enum hwmon_sensor_types typ
 static const struct hwmon_ops axi_hwmon_ops = {
 	.is_visible = axi_hwmon_is_visible,
 	.read = axi_hwmon_read,
+	.write = axi_hwmon_write,
 	.read_string = axi_hwmon_read_string,
 };
 
@@ -565,7 +667,7 @@ static const struct hwmon_channel_info *const axi_hwmon_info[] = {
 	HWMON_CHANNEL_INFO(fan,
 			   HWMON_F_INPUT | HWMON_F_LABEL),
 	HWMON_CHANNEL_INFO(pwm,
-			   HWMON_PWM_ENABLE),
+			   HWMON_PWM_INPUT | HWMON_PWM_ENABLE),
 	HWMON_CHANNEL_INFO(power,
 			   HWMON_P_INPUT | HWMON_P_LABEL,
 			   HWMON_P_INPUT | HWMON_P_LABEL,
@@ -731,11 +833,28 @@ static int axi_read_bridge_info_locked(struct corsairpsu_axi_data *priv)
 	return first_error;
 }
 
+static int axi_check_fan_pwm_locked(struct corsairpsu_axi_data *priv)
+{
+	u8 dutycycle;
+	int ret;
+
+	ret = axi_read_register_locked(priv, AXI_REG_FAN_PWM, &dutycycle,
+				       sizeof(dutycycle));
+	if (ret)
+		return ret;
+	if (dutycycle > 100)
+		return -ERANGE;
+
+	priv->fan_pwm_supported = true;
+	return 0;
+}
+
 static int axi_probe(struct usb_interface *interface, const struct usb_device_id *id)
 {
 	struct corsairpsu_axi_data *priv;
 	u8 product[sizeof(priv->product) - 1];
 	int bridge_ret = 0;
+	int fan_pwm_ret = 0;
 	int ret;
 
 	priv = devm_kzalloc(&interface->dev, sizeof(*priv), GFP_KERNEL);
@@ -771,12 +890,17 @@ static int axi_probe(struct usb_interface *interface, const struct usb_device_id
 		ret = axi_read_register_locked(priv, AXI_REG_PRODUCT, product, sizeof(product));
 	if (!ret)
 		bridge_ret = axi_read_bridge_info_locked(priv);
+	if (!ret)
+		fan_pwm_ret = axi_check_fan_pwm_locked(priv);
 	mutex_unlock(&priv->lock);
 	if (ret)
 		goto err_put_dev;
 	if (bridge_ret)
 		dev_warn(&interface->dev, "unable to read USB bridge metadata (%d)\n",
 			 bridge_ret);
+	if (fan_pwm_ret)
+		dev_warn(&interface->dev, "fan duty-cycle control unavailable (%d)\n",
+			 fan_pwm_ret);
 
 	memcpy(priv->product, product, sizeof(product));
 	priv->product[sizeof(product)] = '\0';

--- a/corsair-psu-axi.c
+++ b/corsair-psu-axi.c
@@ -7,9 +7,14 @@
  *
  * AX1600i transport and register protocol based on the corsair-top project:
  * https://github.com/thad0ctor/corsair-top
+ *
+ * 12V page telemetry, fan mode, uptime, and USB bridge metadata based on
+ * protocol research by Jon0:
+ * https://github.com/Jon0/ax1600i
  */
 
 #include <linux/delay.h>
+#include <linux/debugfs.h>
 #include <linux/errno.h>
 #include <linux/hwmon.h>
 #include <linux/kernel.h>
@@ -25,8 +30,9 @@
 #define CORSAIR_AX1600I_ID	0x1c11
 
 #define AXI_USB_TIMEOUT_MS	1000
-#define AXI_MAX_ENCODED_SIZE	64
-#define AXI_MAX_DECODED_SIZE	31
+#define AXI_MAX_TX_SIZE		64
+#define AXI_MAX_RX_SIZE		128
+#define AXI_MAX_DECODED_SIZE	((AXI_MAX_RX_SIZE - 2) / 2)
 
 #define AXI_CMD_SETUP		0x11
 #define AXI_CMD_EXECUTE		0x12
@@ -44,10 +50,22 @@
 #define AXI_REG_RAIL_WATTS	0x96
 #define AXI_REG_PRODUCT		0x9a
 #define AXI_REG_UPTIME		0xd2
+#define AXI_REG_12V_PAGE		0xe7
+#define AXI_REG_12V_AMPS		0xe8
+#define AXI_REG_12V_WATTS	0xe9
+#define AXI_REG_12V_OCP		0xea
 #define AXI_REG_TOTAL_WATTS	0xee
+#define AXI_REG_FAN_MODE		0xf0
 
 #define AXI_RAIL_COUNT		3
 #define AXI_TEMP_COUNT		2
+#define AXI_12V_PAGE_COUNT	12
+#define AXI_BASE_POWER_COUNT	(AXI_RAIL_COUNT + 1)
+#define AXI_BASE_CURR_COUNT	(AXI_RAIL_COUNT + 1)
+#define AXI_POWER_COUNT		(AXI_BASE_POWER_COUNT + AXI_12V_PAGE_COUNT)
+#define AXI_CURR_COUNT		(AXI_BASE_CURR_COUNT + AXI_12V_PAGE_COUNT)
+#define AXI_BRIDGE_VERSION_SIZE	3
+#define AXI_BRIDGE_FIRMWARE_SIZE	64
 
 #define L_IN_VOLTS		"v_in"
 #define L_OUT_VOLTS_12V		"v_out +12v"
@@ -82,16 +100,27 @@ static const char *const label_amps[] = {
 	L_IN_AMPS, L_AMPS_12V, L_AMPS_5V, L_AMPS_3_3V
 };
 
+static const char *const label_12v_pages[] = {
+	"12v page 0", "12v page 1", "12v page 2", "12v page 3",
+	"12v page 4", "12v page 5", "12v page 6", "12v page 7",
+	"12v page 8", "12v page 9", "12v page 10", "12v page 11"
+};
+
 struct corsairpsu_axi_data {
 	struct usb_device *udev;
 	struct usb_interface *interface;
 	struct device *hwmon_dev;
+	struct dentry *debugfs;
 	struct mutex lock;
 	u8 bulk_in;
 	u8 bulk_out;
 	u8 *tx_buffer;
 	u8 *rx_buffer;
+	u8 bridge_version[AXI_BRIDGE_VERSION_SIZE];
+	char bridge_firmware[AXI_BRIDGE_FIRMWARE_SIZE];
 	char product[8];
+	bool bridge_version_valid;
+	bool bridge_firmware_valid;
 	bool disconnected;
 };
 
@@ -155,10 +184,11 @@ static int axi_exchange(struct corsairpsu_axi_data *priv, const u8 *request,
 {
 	int encoded_len;
 	int actual_len;
+	int total_len = 0;
 	int ret;
 
 	encoded_len = axi_encode(request, request_len, priv->tx_buffer,
-				 AXI_MAX_ENCODED_SIZE);
+				 AXI_MAX_TX_SIZE);
 	if (encoded_len < 0)
 		return encoded_len;
 
@@ -171,15 +201,24 @@ static int axi_exchange(struct corsairpsu_axi_data *priv, const u8 *request,
 	if (actual_len != encoded_len)
 		return -EIO;
 
-	ret = usb_bulk_msg(priv->udev, usb_rcvbulkpipe(priv->udev, priv->bulk_in),
-			   priv->rx_buffer, AXI_MAX_ENCODED_SIZE, &actual_len,
-			   AXI_USB_TIMEOUT_MS);
-	if (ret)
-		return ret;
-	if (!actual_len)
-		return -ENODATA;
+	do {
+		if (total_len >= AXI_MAX_RX_SIZE)
+			return -EMSGSIZE;
 
-	return axi_decode(priv->rx_buffer, actual_len, response, response_size);
+		ret = usb_bulk_msg(priv->udev,
+				   usb_rcvbulkpipe(priv->udev, priv->bulk_in),
+				   priv->rx_buffer + total_len,
+				   AXI_MAX_RX_SIZE - total_len, &actual_len,
+				   AXI_USB_TIMEOUT_MS);
+		if (ret)
+			return ret;
+		if (!actual_len)
+			return -ENODATA;
+
+		total_len += actual_len;
+	} while (priv->rx_buffer[total_len - 1] != 0);
+
+	return axi_decode(priv->rx_buffer, total_len, response, response_size);
 }
 
 static int axi_expect_status(struct corsairpsu_axi_data *priv, const u8 *request,
@@ -274,6 +313,31 @@ static int axi_select_rail_locked(struct corsairpsu_axi_data *priv, u8 rail)
 	return axi_write_register_locked(priv, AXI_REG_SELECT_RAIL, &rail, sizeof(rail));
 }
 
+static int axi_select_12v_page_locked(struct corsairpsu_axi_data *priv, u8 page)
+{
+	u8 selected;
+	int ret;
+
+	if (page >= AXI_12V_PAGE_COUNT)
+		return -EINVAL;
+
+	ret = axi_select_rail_locked(priv, 0);
+	if (ret)
+		return ret;
+
+	ret = axi_write_register_locked(priv, AXI_REG_12V_PAGE, &page, sizeof(page));
+	if (ret)
+		return ret;
+
+	usleep_range(5000, 6000);
+	ret = axi_read_register_locked(priv, AXI_REG_12V_PAGE, &selected,
+				       sizeof(selected));
+	if (ret)
+		return ret;
+
+	return selected == page ? 0 : -EIO;
+}
+
 static int axi_linear11_to_int(u16 raw, int scale, long *value)
 {
 	int exponent = sign_extend32(raw >> 11, 4);
@@ -317,6 +381,45 @@ out:
 	return ret;
 }
 
+static int axi_get_raw(struct corsairpsu_axi_data *priv, u8 reg, u8 *data,
+		       u8 data_len)
+{
+	int ret;
+
+	mutex_lock(&priv->lock);
+	if (priv->disconnected)
+		ret = -ENODEV;
+	else
+		ret = axi_read_register_locked(priv, reg, data, data_len);
+	mutex_unlock(&priv->lock);
+
+	return ret;
+}
+
+static int axi_get_12v_page_value(struct corsairpsu_axi_data *priv, u8 reg,
+				  int page, int scale, long *value)
+{
+	u8 data[2];
+	int ret;
+
+	mutex_lock(&priv->lock);
+	if (priv->disconnected) {
+		ret = -ENODEV;
+		goto out;
+	}
+
+	ret = axi_select_12v_page_locked(priv, page);
+	if (ret)
+		goto out;
+
+	ret = axi_read_register_locked(priv, reg, data, sizeof(data));
+	if (!ret)
+		ret = axi_linear11_to_int(get_unaligned_le16(data), scale, value);
+out:
+	mutex_unlock(&priv->lock);
+	return ret;
+}
+
 static umode_t axi_hwmon_is_visible(const void *data, enum hwmon_sensor_types type,
 				    u32 attr, int channel)
 {
@@ -327,10 +430,15 @@ static umode_t axi_hwmon_is_visible(const void *data, enum hwmon_sensor_types ty
 		return (attr == hwmon_fan_input || attr == hwmon_fan_label) ? 0444 : 0;
 	case hwmon_power:
 		return (attr == hwmon_power_input || attr == hwmon_power_label) ? 0444 : 0;
+	case hwmon_pwm:
+		return (attr == hwmon_pwm_enable && !channel) ? 0444 : 0;
 	case hwmon_in:
 		return (attr == hwmon_in_input || attr == hwmon_in_label) ? 0444 : 0;
 	case hwmon_curr:
-		return (attr == hwmon_curr_input || attr == hwmon_curr_label) ? 0444 : 0;
+		if (attr == hwmon_curr_input || attr == hwmon_curr_label)
+			return 0444;
+		return (attr == hwmon_curr_max && channel >= AXI_BASE_CURR_COUNT &&
+			channel < AXI_CURR_COUNT) ? 0444 : 0;
 	default:
 		return 0;
 	}
@@ -340,6 +448,8 @@ static int axi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 			  u32 attr, int channel, long *value)
 {
 	struct corsairpsu_axi_data *priv = dev_get_drvdata(dev);
+	u8 data;
+	int ret;
 
 	switch (type) {
 	case hwmon_temp:
@@ -352,12 +462,30 @@ static int axi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 			return -EOPNOTSUPP;
 		return axi_get_value(priv, AXI_REG_FAN, -1, 1, value);
 	case hwmon_power:
-		if (attr != hwmon_power_input || channel > AXI_RAIL_COUNT)
+		if (attr != hwmon_power_input || channel >= AXI_POWER_COUNT)
 			return -EOPNOTSUPP;
+		if (channel >= AXI_BASE_POWER_COUNT)
+			return axi_get_12v_page_value(priv, AXI_REG_12V_WATTS,
+						     channel - AXI_BASE_POWER_COUNT,
+						     1000000, value);
 		if (!channel)
 			return axi_get_value(priv, AXI_REG_TOTAL_WATTS, -1, 1000000, value);
 		return axi_get_value(priv, AXI_REG_RAIL_WATTS, channel - 1,
 				     1000000, value);
+	case hwmon_pwm:
+		if (attr != hwmon_pwm_enable || channel)
+			return -EOPNOTSUPP;
+		ret = axi_get_raw(priv, AXI_REG_FAN_MODE, &data, sizeof(data));
+		if (ret)
+			return ret;
+		/* The PSU reports 0 for automatic mode and 1 for fixed-speed mode. */
+		if (data == 0)
+			*value = 2;
+		else if (data == 1)
+			*value = 1;
+		else
+			return -EIO;
+		return 0;
 	case hwmon_in:
 		if (attr != hwmon_in_input || channel > AXI_RAIL_COUNT)
 			return -EOPNOTSUPP;
@@ -365,7 +493,20 @@ static int axi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 			return axi_get_value(priv, AXI_REG_IN_VOLTS, -1, 1000, value);
 		return axi_get_value(priv, AXI_REG_RAIL_VOLTS, channel - 1, 1000, value);
 	case hwmon_curr:
-		if (attr != hwmon_curr_input || channel > AXI_RAIL_COUNT)
+		if (channel >= AXI_CURR_COUNT)
+			return -EOPNOTSUPP;
+		if (channel >= AXI_BASE_CURR_COUNT) {
+			if (attr == hwmon_curr_input)
+				return axi_get_12v_page_value(priv, AXI_REG_12V_AMPS,
+							     channel - AXI_BASE_CURR_COUNT,
+							     1000, value);
+			if (attr == hwmon_curr_max)
+				return axi_get_12v_page_value(priv, AXI_REG_12V_OCP,
+							     channel - AXI_BASE_CURR_COUNT,
+							     1000, value);
+			return -EOPNOTSUPP;
+		}
+		if (attr != hwmon_curr_input)
 			return -EOPNOTSUPP;
 		if (!channel)
 			return axi_get_value(priv, AXI_REG_IN_AMPS, -1, 1000, value);
@@ -387,8 +528,11 @@ static int axi_hwmon_read_string(struct device *dev, enum hwmon_sensor_types typ
 		return 0;
 	}
 	if (type == hwmon_power && attr == hwmon_power_label &&
-	    channel < ARRAY_SIZE(label_watts)) {
-		*str = label_watts[channel];
+	    channel < AXI_POWER_COUNT) {
+		if (channel < ARRAY_SIZE(label_watts))
+			*str = label_watts[channel];
+		else
+			*str = label_12v_pages[channel - AXI_BASE_POWER_COUNT];
 		return 0;
 	}
 	if (type == hwmon_in && attr == hwmon_in_label &&
@@ -397,8 +541,11 @@ static int axi_hwmon_read_string(struct device *dev, enum hwmon_sensor_types typ
 		return 0;
 	}
 	if (type == hwmon_curr && attr == hwmon_curr_label &&
-	    channel < ARRAY_SIZE(label_amps)) {
-		*str = label_amps[channel];
+	    channel < AXI_CURR_COUNT) {
+		if (channel < ARRAY_SIZE(label_amps))
+			*str = label_amps[channel];
+		else
+			*str = label_12v_pages[channel - AXI_BASE_CURR_COUNT];
 		return 0;
 	}
 
@@ -417,7 +564,21 @@ static const struct hwmon_channel_info *const axi_hwmon_info[] = {
 			   HWMON_T_INPUT | HWMON_T_LABEL),
 	HWMON_CHANNEL_INFO(fan,
 			   HWMON_F_INPUT | HWMON_F_LABEL),
+	HWMON_CHANNEL_INFO(pwm,
+			   HWMON_PWM_ENABLE),
 	HWMON_CHANNEL_INFO(power,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
 			   HWMON_P_INPUT | HWMON_P_LABEL,
 			   HWMON_P_INPUT | HWMON_P_LABEL,
 			   HWMON_P_INPUT | HWMON_P_LABEL,
@@ -431,7 +592,19 @@ static const struct hwmon_channel_info *const axi_hwmon_info[] = {
 			   HWMON_C_INPUT | HWMON_C_LABEL,
 			   HWMON_C_INPUT | HWMON_C_LABEL,
 			   HWMON_C_INPUT | HWMON_C_LABEL,
-			   HWMON_C_INPUT | HWMON_C_LABEL),
+			   HWMON_C_INPUT | HWMON_C_LABEL,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX,
+			   HWMON_C_INPUT | HWMON_C_LABEL | HWMON_C_MAX),
 	NULL
 };
 
@@ -439,6 +612,73 @@ static const struct hwmon_chip_info axi_chip_info = {
 	.ops = &axi_hwmon_ops,
 	.info = axi_hwmon_info,
 };
+
+#ifdef CONFIG_DEBUG_FS
+
+static int axi_uptime_show(struct seq_file *seqf, void *unused)
+{
+	struct corsairpsu_axi_data *priv = seqf->private;
+	u8 data[2];
+	u16 seconds;
+	int ret;
+
+	ret = axi_get_raw(priv, AXI_REG_UPTIME, data, sizeof(data));
+	if (ret)
+		return ret;
+
+	seconds = get_unaligned_le16(data);
+	seq_printf(seqf, "%u\n", seconds);
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(axi_uptime);
+
+static int axi_bridge_version_show(struct seq_file *seqf, void *unused)
+{
+	struct corsairpsu_axi_data *priv = seqf->private;
+
+	if (!priv->bridge_version_valid)
+		return -ENODATA;
+
+	seq_printf(seqf, "%u.%u.%u\n", priv->bridge_version[0],
+		   priv->bridge_version[1], priv->bridge_version[2]);
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(axi_bridge_version);
+
+static int axi_bridge_firmware_show(struct seq_file *seqf, void *unused)
+{
+	struct corsairpsu_axi_data *priv = seqf->private;
+
+	if (!priv->bridge_firmware_valid)
+		return -ENODATA;
+
+	seq_printf(seqf, "%s\n", priv->bridge_firmware);
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(axi_bridge_firmware);
+
+static void axi_debugfs_init(struct corsairpsu_axi_data *priv)
+{
+	char name[48];
+
+	scnprintf(name, sizeof(name), "%s-%s", DRIVER_NAME,
+		  dev_name(&priv->interface->dev));
+	priv->debugfs = debugfs_create_dir(name, NULL);
+	debugfs_create_file("uptime", 0444, priv->debugfs, priv,
+			    &axi_uptime_fops);
+	debugfs_create_file("bridge_version", 0444, priv->debugfs, priv,
+			    &axi_bridge_version_fops);
+	debugfs_create_file("bridge_firmware", 0444, priv->debugfs, priv,
+			    &axi_bridge_firmware_fops);
+}
+
+#else
+
+static void axi_debugfs_init(struct corsairpsu_axi_data *priv)
+{
+}
+
+#endif
 
 static int axi_find_endpoints(struct usb_interface *interface,
 			      struct corsairpsu_axi_data *priv)
@@ -458,10 +698,44 @@ static int axi_find_endpoints(struct usb_interface *interface,
 	return priv->bulk_in && priv->bulk_out ? 0 : -ENODEV;
 }
 
+static int axi_read_bridge_info_locked(struct corsairpsu_axi_data *priv)
+{
+	static const u8 version_request[] = { 0x00 };
+	static const u8 firmware_request[] = { 0x02 };
+	u8 firmware[AXI_BRIDGE_FIRMWARE_SIZE - 1];
+	int first_error = 0;
+	int ret;
+
+	ret = axi_exchange(priv, version_request, sizeof(version_request),
+			   priv->bridge_version, sizeof(priv->bridge_version));
+	/*
+	 * The bridge reports major and minor bytes. Jon0's decoder also returns
+	 * the encoded frame terminator as a zero-valued patch byte.
+	 */
+	if (ret == AXI_BRIDGE_VERSION_SIZE - 1 ||
+	    ret == AXI_BRIDGE_VERSION_SIZE)
+		priv->bridge_version_valid = true;
+	else
+		first_error = ret < 0 ? ret : -EPROTO;
+
+	ret = axi_exchange(priv, firmware_request, sizeof(firmware_request),
+			   firmware, sizeof(firmware));
+	if (ret > 0) {
+		memcpy(priv->bridge_firmware, firmware, ret);
+		priv->bridge_firmware[ret] = '\0';
+		priv->bridge_firmware_valid = true;
+	} else if (!first_error) {
+		first_error = ret < 0 ? ret : -EPROTO;
+	}
+
+	return first_error;
+}
+
 static int axi_probe(struct usb_interface *interface, const struct usb_device_id *id)
 {
 	struct corsairpsu_axi_data *priv;
 	u8 product[sizeof(priv->product) - 1];
+	int bridge_ret = 0;
 	int ret;
 
 	priv = devm_kzalloc(&interface->dev, sizeof(*priv), GFP_KERNEL);
@@ -470,9 +744,9 @@ static int axi_probe(struct usb_interface *interface, const struct usb_device_id
 
 	priv->udev = usb_get_dev(interface_to_usbdev(interface));
 	priv->interface = interface;
-	priv->tx_buffer = devm_kmalloc(&interface->dev, AXI_MAX_ENCODED_SIZE,
+	priv->tx_buffer = devm_kmalloc(&interface->dev, AXI_MAX_TX_SIZE,
 				      GFP_KERNEL);
-	priv->rx_buffer = devm_kmalloc(&interface->dev, AXI_MAX_ENCODED_SIZE,
+	priv->rx_buffer = devm_kmalloc(&interface->dev, AXI_MAX_RX_SIZE,
 				      GFP_KERNEL);
 	if (!priv->tx_buffer || !priv->rx_buffer) {
 		ret = -ENOMEM;
@@ -495,9 +769,14 @@ static int axi_probe(struct usb_interface *interface, const struct usb_device_id
 	ret = axi_setup(priv);
 	if (!ret)
 		ret = axi_read_register_locked(priv, AXI_REG_PRODUCT, product, sizeof(product));
+	if (!ret)
+		bridge_ret = axi_read_bridge_info_locked(priv);
 	mutex_unlock(&priv->lock);
 	if (ret)
 		goto err_put_dev;
+	if (bridge_ret)
+		dev_warn(&interface->dev, "unable to read USB bridge metadata (%d)\n",
+			 bridge_ret);
 
 	memcpy(priv->product, product, sizeof(product));
 	priv->product[sizeof(product)] = '\0';
@@ -514,6 +793,7 @@ static int axi_probe(struct usb_interface *interface, const struct usb_device_id
 		goto err_put_dev;
 	}
 
+	axi_debugfs_init(priv);
 	dev_info(&interface->dev, "Corsair %s power supply connected\n", priv->product);
 	return 0;
 
@@ -534,6 +814,7 @@ static void axi_disconnect(struct usb_interface *interface)
 	mutex_lock(&priv->lock);
 	priv->disconnected = true;
 	mutex_unlock(&priv->lock);
+	debugfs_remove_recursive(priv->debugfs);
 	hwmon_device_unregister(priv->hwmon_dev);
 	usb_put_dev(priv->udev);
 }

--- a/corsair-psu-axi.c
+++ b/corsair-psu-axi.c
@@ -1,0 +1,557 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * corsair-psu-axi.c - Linux hwmon driver for Corsair AXi power supplies
+ *
+ * The AX1600i exposes a vendor-specific bulk USB interface instead of the
+ * HID interface used by Corsair RMi and HXi power supplies.
+ *
+ * AX1600i transport and register protocol based on the corsair-top project:
+ * https://github.com/thad0ctor/corsair-top
+ */
+
+#include <linux/delay.h>
+#include <linux/errno.h>
+#include <linux/hwmon.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/slab.h>
+#include <linux/unaligned.h>
+#include <linux/usb.h>
+
+#define DRIVER_NAME		"corsair-psu-axi"
+
+#define CORSAIR_VENDOR_ID	0x1b1c
+#define CORSAIR_AX1600I_ID	0x1c11
+
+#define AXI_USB_TIMEOUT_MS	1000
+#define AXI_MAX_ENCODED_SIZE	64
+#define AXI_MAX_DECODED_SIZE	31
+
+#define AXI_CMD_SETUP		0x11
+#define AXI_CMD_EXECUTE		0x12
+#define AXI_CMD_TRANSFER	0x13
+#define AXI_CMD_READ		0x08
+
+#define AXI_REG_SELECT_RAIL	0x00
+#define AXI_REG_IN_VOLTS	0x88
+#define AXI_REG_IN_AMPS		0x89
+#define AXI_REG_RAIL_VOLTS	0x8b
+#define AXI_REG_RAIL_AMPS	0x8c
+#define AXI_REG_TEMP0		0x8d
+#define AXI_REG_TEMP1		0x8e
+#define AXI_REG_FAN		0x90
+#define AXI_REG_RAIL_WATTS	0x96
+#define AXI_REG_PRODUCT		0x9a
+#define AXI_REG_UPTIME		0xd2
+#define AXI_REG_TOTAL_WATTS	0xee
+
+#define AXI_RAIL_COUNT		3
+#define AXI_TEMP_COUNT		2
+
+#define L_IN_VOLTS		"v_in"
+#define L_OUT_VOLTS_12V		"v_out +12v"
+#define L_OUT_VOLTS_5V		"v_out +5v"
+#define L_OUT_VOLTS_3_3V	"v_out +3.3v"
+#define L_IN_AMPS		"curr in"
+#define L_AMPS_12V		"curr +12v"
+#define L_AMPS_5V		"curr +5v"
+#define L_AMPS_3_3V		"curr +3.3v"
+#define L_FAN			"psu fan"
+#define L_TEMP0			"vrm temp"
+#define L_TEMP1			"case temp"
+#define L_WATTS			"power total"
+#define L_WATTS_12V		"power +12v"
+#define L_WATTS_5V		"power +5v"
+#define L_WATTS_3_3V		"power +3.3v"
+
+static const u8 axi_encode_table[] = {
+	0x55, 0x56, 0x59, 0x5a, 0x65, 0x66, 0x69, 0x6a,
+	0x95, 0x96, 0x99, 0x9a, 0xa5, 0xa6, 0xa9, 0xaa
+};
+
+static const char *const label_watts[] = {
+	L_WATTS, L_WATTS_12V, L_WATTS_5V, L_WATTS_3_3V
+};
+
+static const char *const label_volts[] = {
+	L_IN_VOLTS, L_OUT_VOLTS_12V, L_OUT_VOLTS_5V, L_OUT_VOLTS_3_3V
+};
+
+static const char *const label_amps[] = {
+	L_IN_AMPS, L_AMPS_12V, L_AMPS_5V, L_AMPS_3_3V
+};
+
+struct corsairpsu_axi_data {
+	struct usb_device *udev;
+	struct usb_interface *interface;
+	struct device *hwmon_dev;
+	struct mutex lock;
+	u8 bulk_in;
+	u8 bulk_out;
+	u8 *tx_buffer;
+	u8 *rx_buffer;
+	char product[8];
+	bool disconnected;
+};
+
+static int axi_decode_nibble(u8 encoded)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(axi_encode_table); i++)
+		if (axi_encode_table[i] == encoded)
+			return i;
+
+	return -EPROTO;
+}
+
+static int axi_encode(const u8 *src, size_t src_len, u8 *dst, size_t dst_size)
+{
+	size_t i;
+
+	if (src_len > (dst_size - 2) / 2)
+		return -EMSGSIZE;
+
+	dst[0] = axi_encode_table[0] & 0xfc;
+	for (i = 0; i < src_len; i++) {
+		dst[1 + i * 2] = axi_encode_table[src[i] & 0x0f];
+		dst[2 + i * 2] = axi_encode_table[src[i] >> 4];
+	}
+	dst[1 + src_len * 2] = 0;
+
+	return 2 + src_len * 2;
+}
+
+static int axi_decode(const u8 *src, size_t src_len, u8 *dst, size_t dst_size)
+{
+	size_t encoded_payload_len;
+	size_t i;
+	int low;
+	int high;
+
+	if (src_len < 2 || src[src_len - 1] != 0)
+		return -EPROTO;
+
+	encoded_payload_len = src_len - 2;
+	if (encoded_payload_len & 1)
+		return -EPROTO;
+	if (encoded_payload_len / 2 > dst_size)
+		return -EMSGSIZE;
+
+	for (i = 0; i < encoded_payload_len / 2; i++) {
+		low = axi_decode_nibble(src[1 + i * 2]);
+		high = axi_decode_nibble(src[2 + i * 2]);
+		if (low < 0 || high < 0)
+			return -EPROTO;
+		dst[i] = low | (high << 4);
+	}
+
+	return encoded_payload_len / 2;
+}
+
+static int axi_exchange(struct corsairpsu_axi_data *priv, const u8 *request,
+			size_t request_len, u8 *response, size_t response_size)
+{
+	int encoded_len;
+	int actual_len;
+	int ret;
+
+	encoded_len = axi_encode(request, request_len, priv->tx_buffer,
+				 AXI_MAX_ENCODED_SIZE);
+	if (encoded_len < 0)
+		return encoded_len;
+
+	usleep_range(1000, 2000);
+	ret = usb_bulk_msg(priv->udev, usb_sndbulkpipe(priv->udev, priv->bulk_out),
+			   priv->tx_buffer, encoded_len, &actual_len,
+			   AXI_USB_TIMEOUT_MS);
+	if (ret)
+		return ret;
+	if (actual_len != encoded_len)
+		return -EIO;
+
+	ret = usb_bulk_msg(priv->udev, usb_rcvbulkpipe(priv->udev, priv->bulk_in),
+			   priv->rx_buffer, AXI_MAX_ENCODED_SIZE, &actual_len,
+			   AXI_USB_TIMEOUT_MS);
+	if (ret)
+		return ret;
+	if (!actual_len)
+		return -ENODATA;
+
+	return axi_decode(priv->rx_buffer, actual_len, response, response_size);
+}
+
+static int axi_expect_status(struct corsairpsu_axi_data *priv, const u8 *request,
+			     size_t request_len)
+{
+	u8 response[2];
+	int ret;
+
+	ret = axi_exchange(priv, request, request_len, response, sizeof(response));
+	if (ret < 0)
+		return ret;
+	if (ret && response[0])
+		return -EIO;
+
+	return 0;
+}
+
+static int axi_setup(struct corsairpsu_axi_data *priv)
+{
+	static const u8 setup[] = {
+		AXI_CMD_SETUP, 0x02, 0x64, 0x00, 0x00, 0x00, 0x00
+	};
+
+	return axi_expect_status(priv, setup, sizeof(setup));
+}
+
+static int axi_read_register_locked(struct corsairpsu_axi_data *priv, u8 reg,
+				    u8 *data, u8 data_len)
+{
+	u8 response[AXI_MAX_DECODED_SIZE];
+	u8 request[] = {
+		AXI_CMD_TRANSFER, 0x03, 0x06, 0x01, 0x07, data_len, reg
+	};
+	static const u8 execute[] = { AXI_CMD_EXECUTE };
+	u8 read[] = { AXI_CMD_READ, 0x07, data_len };
+	int ret;
+
+	ret = axi_expect_status(priv, request, sizeof(request));
+	if (ret)
+		return ret;
+
+	ret = axi_exchange(priv, execute, sizeof(execute), response, sizeof(response));
+	if (ret < 0)
+		return ret;
+	if (ret && response[0])
+		return -EIO;
+
+	ret = axi_exchange(priv, read, sizeof(read), response, sizeof(response));
+	if (ret < data_len)
+		return ret < 0 ? ret : -EPROTO;
+
+	memcpy(data, response, data_len);
+	return 0;
+}
+
+static int axi_write_register_locked(struct corsairpsu_axi_data *priv, u8 reg,
+				     const u8 *data, u8 data_len)
+{
+	u8 request[5 + 1];
+	u8 response[2];
+	static const u8 execute[] = { AXI_CMD_EXECUTE };
+	int ret;
+
+	if (data_len != 1)
+		return -EINVAL;
+
+	request[0] = AXI_CMD_TRANSFER;
+	request[1] = 0x01;
+	request[2] = 0x04;
+	request[3] = data_len;
+	request[4] = reg;
+	request[5] = data[0];
+
+	ret = axi_expect_status(priv, request, sizeof(request));
+	if (ret)
+		return ret;
+
+	ret = axi_exchange(priv, execute, sizeof(execute), response, sizeof(response));
+	if (ret < 0)
+		return ret;
+	if (ret && response[0])
+		return -EIO;
+
+	return 0;
+}
+
+static int axi_select_rail_locked(struct corsairpsu_axi_data *priv, u8 rail)
+{
+	if (rail >= AXI_RAIL_COUNT)
+		return -EINVAL;
+
+	return axi_write_register_locked(priv, AXI_REG_SELECT_RAIL, &rail, sizeof(rail));
+}
+
+static int axi_linear11_to_int(u16 raw, int scale, long *value)
+{
+	int exponent = sign_extend32(raw >> 11, 4);
+	int mantissa = sign_extend32(raw & 0x7ff, 10);
+	s64 result = (s64)mantissa * scale;
+
+	if (exponent >= 0)
+		result <<= exponent;
+	else
+		result >>= -exponent;
+
+	if (result > LONG_MAX || result < LONG_MIN)
+		return -ERANGE;
+
+	*value = result;
+	return 0;
+}
+
+static int axi_get_value(struct corsairpsu_axi_data *priv, u8 reg, int rail,
+			 int scale, long *value)
+{
+	u8 data[2];
+	int ret;
+
+	mutex_lock(&priv->lock);
+	if (priv->disconnected) {
+		ret = -ENODEV;
+		goto out;
+	}
+	if (rail >= 0) {
+		ret = axi_select_rail_locked(priv, rail);
+		if (ret)
+			goto out;
+	}
+
+	ret = axi_read_register_locked(priv, reg, data, sizeof(data));
+	if (!ret)
+		ret = axi_linear11_to_int(get_unaligned_le16(data), scale, value);
+out:
+	mutex_unlock(&priv->lock);
+	return ret;
+}
+
+static umode_t axi_hwmon_is_visible(const void *data, enum hwmon_sensor_types type,
+				    u32 attr, int channel)
+{
+	switch (type) {
+	case hwmon_temp:
+		return (attr == hwmon_temp_input || attr == hwmon_temp_label) ? 0444 : 0;
+	case hwmon_fan:
+		return (attr == hwmon_fan_input || attr == hwmon_fan_label) ? 0444 : 0;
+	case hwmon_power:
+		return (attr == hwmon_power_input || attr == hwmon_power_label) ? 0444 : 0;
+	case hwmon_in:
+		return (attr == hwmon_in_input || attr == hwmon_in_label) ? 0444 : 0;
+	case hwmon_curr:
+		return (attr == hwmon_curr_input || attr == hwmon_curr_label) ? 0444 : 0;
+	default:
+		return 0;
+	}
+}
+
+static int axi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
+			  u32 attr, int channel, long *value)
+{
+	struct corsairpsu_axi_data *priv = dev_get_drvdata(dev);
+
+	switch (type) {
+	case hwmon_temp:
+		if (attr != hwmon_temp_input || channel >= AXI_TEMP_COUNT)
+			return -EOPNOTSUPP;
+		return axi_get_value(priv, channel ? AXI_REG_TEMP1 : AXI_REG_TEMP0,
+				     -1, 1000, value);
+	case hwmon_fan:
+		if (attr != hwmon_fan_input || channel)
+			return -EOPNOTSUPP;
+		return axi_get_value(priv, AXI_REG_FAN, -1, 1, value);
+	case hwmon_power:
+		if (attr != hwmon_power_input || channel > AXI_RAIL_COUNT)
+			return -EOPNOTSUPP;
+		if (!channel)
+			return axi_get_value(priv, AXI_REG_TOTAL_WATTS, -1, 1000000, value);
+		return axi_get_value(priv, AXI_REG_RAIL_WATTS, channel - 1,
+				     1000000, value);
+	case hwmon_in:
+		if (attr != hwmon_in_input || channel > AXI_RAIL_COUNT)
+			return -EOPNOTSUPP;
+		if (!channel)
+			return axi_get_value(priv, AXI_REG_IN_VOLTS, -1, 1000, value);
+		return axi_get_value(priv, AXI_REG_RAIL_VOLTS, channel - 1, 1000, value);
+	case hwmon_curr:
+		if (attr != hwmon_curr_input || channel > AXI_RAIL_COUNT)
+			return -EOPNOTSUPP;
+		if (!channel)
+			return axi_get_value(priv, AXI_REG_IN_AMPS, -1, 1000, value);
+		return axi_get_value(priv, AXI_REG_RAIL_AMPS, channel - 1, 1000, value);
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static int axi_hwmon_read_string(struct device *dev, enum hwmon_sensor_types type,
+				 u32 attr, int channel, const char **str)
+{
+	if (type == hwmon_temp && attr == hwmon_temp_label && channel < AXI_TEMP_COUNT) {
+		*str = channel ? L_TEMP1 : L_TEMP0;
+		return 0;
+	}
+	if (type == hwmon_fan && attr == hwmon_fan_label && !channel) {
+		*str = L_FAN;
+		return 0;
+	}
+	if (type == hwmon_power && attr == hwmon_power_label &&
+	    channel < ARRAY_SIZE(label_watts)) {
+		*str = label_watts[channel];
+		return 0;
+	}
+	if (type == hwmon_in && attr == hwmon_in_label &&
+	    channel < ARRAY_SIZE(label_volts)) {
+		*str = label_volts[channel];
+		return 0;
+	}
+	if (type == hwmon_curr && attr == hwmon_curr_label &&
+	    channel < ARRAY_SIZE(label_amps)) {
+		*str = label_amps[channel];
+		return 0;
+	}
+
+	return -EOPNOTSUPP;
+}
+
+static const struct hwmon_ops axi_hwmon_ops = {
+	.is_visible = axi_hwmon_is_visible,
+	.read = axi_hwmon_read,
+	.read_string = axi_hwmon_read_string,
+};
+
+static const struct hwmon_channel_info *const axi_hwmon_info[] = {
+	HWMON_CHANNEL_INFO(temp,
+			   HWMON_T_INPUT | HWMON_T_LABEL,
+			   HWMON_T_INPUT | HWMON_T_LABEL),
+	HWMON_CHANNEL_INFO(fan,
+			   HWMON_F_INPUT | HWMON_F_LABEL),
+	HWMON_CHANNEL_INFO(power,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL,
+			   HWMON_P_INPUT | HWMON_P_LABEL),
+	HWMON_CHANNEL_INFO(in,
+			   HWMON_I_INPUT | HWMON_I_LABEL,
+			   HWMON_I_INPUT | HWMON_I_LABEL,
+			   HWMON_I_INPUT | HWMON_I_LABEL,
+			   HWMON_I_INPUT | HWMON_I_LABEL),
+	HWMON_CHANNEL_INFO(curr,
+			   HWMON_C_INPUT | HWMON_C_LABEL,
+			   HWMON_C_INPUT | HWMON_C_LABEL,
+			   HWMON_C_INPUT | HWMON_C_LABEL,
+			   HWMON_C_INPUT | HWMON_C_LABEL),
+	NULL
+};
+
+static const struct hwmon_chip_info axi_chip_info = {
+	.ops = &axi_hwmon_ops,
+	.info = axi_hwmon_info,
+};
+
+static int axi_find_endpoints(struct usb_interface *interface,
+			      struct corsairpsu_axi_data *priv)
+{
+	struct usb_host_interface *alt = interface->cur_altsetting;
+	struct usb_endpoint_descriptor *endpoint;
+	int i;
+
+	for (i = 0; i < alt->desc.bNumEndpoints; i++) {
+		endpoint = &alt->endpoint[i].desc;
+		if (usb_endpoint_is_bulk_in(endpoint))
+			priv->bulk_in = usb_endpoint_num(endpoint);
+		else if (usb_endpoint_is_bulk_out(endpoint))
+			priv->bulk_out = usb_endpoint_num(endpoint);
+	}
+
+	return priv->bulk_in && priv->bulk_out ? 0 : -ENODEV;
+}
+
+static int axi_probe(struct usb_interface *interface, const struct usb_device_id *id)
+{
+	struct corsairpsu_axi_data *priv;
+	u8 product[sizeof(priv->product) - 1];
+	int ret;
+
+	priv = devm_kzalloc(&interface->dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+
+	priv->udev = usb_get_dev(interface_to_usbdev(interface));
+	priv->interface = interface;
+	priv->tx_buffer = devm_kmalloc(&interface->dev, AXI_MAX_ENCODED_SIZE,
+				      GFP_KERNEL);
+	priv->rx_buffer = devm_kmalloc(&interface->dev, AXI_MAX_ENCODED_SIZE,
+				      GFP_KERNEL);
+	if (!priv->tx_buffer || !priv->rx_buffer) {
+		ret = -ENOMEM;
+		goto err_put_dev;
+	}
+	mutex_init(&priv->lock);
+	usb_set_intfdata(interface, priv);
+
+	ret = axi_find_endpoints(interface, priv);
+	if (ret)
+		goto err_put_dev;
+
+	ret = usb_control_msg(priv->udev, usb_sndctrlpipe(priv->udev, 0),
+			      0x02, USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_DIR_OUT,
+			      0x0002, 0, NULL, 0, AXI_USB_TIMEOUT_MS);
+	if (ret < 0)
+		goto err_put_dev;
+
+	mutex_lock(&priv->lock);
+	ret = axi_setup(priv);
+	if (!ret)
+		ret = axi_read_register_locked(priv, AXI_REG_PRODUCT, product, sizeof(product));
+	mutex_unlock(&priv->lock);
+	if (ret)
+		goto err_put_dev;
+
+	memcpy(priv->product, product, sizeof(product));
+	priv->product[sizeof(product)] = '\0';
+	if (strncmp(priv->product, "AX1600i", sizeof(product))) {
+		ret = -ENODEV;
+		goto err_put_dev;
+	}
+
+	priv->hwmon_dev = hwmon_device_register_with_info(&interface->dev,
+							  "corsairpsu_axi", priv,
+							  &axi_chip_info, NULL);
+	if (IS_ERR(priv->hwmon_dev)) {
+		ret = PTR_ERR(priv->hwmon_dev);
+		goto err_put_dev;
+	}
+
+	dev_info(&interface->dev, "Corsair %s power supply connected\n", priv->product);
+	return 0;
+
+err_put_dev:
+	usb_set_intfdata(interface, NULL);
+	usb_put_dev(priv->udev);
+	return ret;
+}
+
+static void axi_disconnect(struct usb_interface *interface)
+{
+	struct corsairpsu_axi_data *priv = usb_get_intfdata(interface);
+
+	if (!priv)
+		return;
+
+	usb_set_intfdata(interface, NULL);
+	mutex_lock(&priv->lock);
+	priv->disconnected = true;
+	mutex_unlock(&priv->lock);
+	hwmon_device_unregister(priv->hwmon_dev);
+	usb_put_dev(priv->udev);
+}
+
+static const struct usb_device_id axi_id_table[] = {
+	{ USB_DEVICE(CORSAIR_VENDOR_ID, CORSAIR_AX1600I_ID) },
+	{ }
+};
+MODULE_DEVICE_TABLE(usb, axi_id_table);
+
+static struct usb_driver axi_driver = {
+	.name = DRIVER_NAME,
+	.probe = axi_probe,
+	.disconnect = axi_disconnect,
+	.id_table = axi_id_table,
+};
+module_usb_driver(axi_driver);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("corsair-psu contributors");
+MODULE_DESCRIPTION("Linux hwmon driver for Corsair AXi power supplies");


### PR DESCRIPTION
## Summary

- add a separate USB hwmon driver for the Corsair AX1600i (`1b1c:1c11`)
- expose input and per-rail voltage, current, and power
- expose PSU temperatures and fan speed
- keep the driver read-only; fan-control and protection registers are not exposed

The AX1600i uses a vendor-specific bulk USB interface rather than the HID transport used by the existing RMi/HXi driver, so this is implemented as `corsair-psu-axi`. Rail selection and reads are serialized, USB responses and bounds are validated, and disconnects are synchronized with hwmon teardown.

## Protocol attribution

The AX1600i transport framing and register protocol are based on the work in [thad0ctor/corsair-top](https://github.com/thad0ctor/corsair-top). Attribution is included in the driver source and README.

## Validation

Tested against a physical Corsair AX1600i on Linux 7.0.0-27-generic:

- built with kernel `W=1` warnings enabled
- loaded successfully with Secure Boot module signing
- verified 12 V, 5 V, 3.3 V, input voltage/current/power, temperatures, and fan speed through `sensors`
- exercised repeated and concurrent hwmon reads
- verified clean unload/reload and userspace `corsair-top` fallback